### PR TITLE
handle Errno::ENETUNREACH in case the ping server is unreachable

### DIFF
--- a/lib/speedtest.rb
+++ b/lib/speedtest.rb
@@ -153,9 +153,7 @@ module Speedtest
 	      begin
 	        page = HTTParty.get("#{server}/speedtest/latency.txt")
 	        times << Time.new - start
-	      rescue Timeout::Error
-	        times << 999999
-	      rescue Net::HTTPNotFound
+	      rescue Timeout::Error, Net::HTTPNotFound, Errno::ENETUNREACH
 	        times << 999999
 	      end
 	    }


### PR DESCRIPTION
I got this error when running petemyron/speedtest master:
```
2.5.1 :010 > results = test.run
Your IP: 68.6.108.105
Your coordinates: [34.4386, -119.7696]
Traceback (most recent call last):
       16: from /usr/local/rvm/gems/ruby-2.5.1/gems/speedtest-0.2.3/lib/speedtest.rb:140:in `block in pick_server'
       15: from /usr/local/rvm/gems/ruby-2.5.1/gems/speedtest-0.2.3/lib/speedtest.rb:151:in `ping'
       14: from /usr/local/rvm/gems/ruby-2.5.1/gems/speedtest-0.2.3/lib/speedtest.rb:151:in `upto'
       13: from /usr/local/rvm/gems/ruby-2.5.1/gems/speedtest-0.2.3/lib/speedtest.rb:154:in `block in ping'
       12: from /usr/local/rvm/gems/ruby-2.5.1/gems/httparty-0.16.2/lib/httparty.rb:601:in `get'
       11: from /usr/local/rvm/gems/ruby-2.5.1/gems/httparty-0.16.2/lib/httparty.rb:489:in `get'
       10: from /usr/local/rvm/gems/ruby-2.5.1/gems/httparty-0.16.2/lib/httparty.rb:563:in `perform_request'
        9: from /usr/local/rvm/gems/ruby-2.5.1/gems/httparty-0.16.2/lib/httparty/request.rb:143:in `perform'
        8: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:1455:in `request'
        7: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:909:in `start'
        6: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:920:in `do_start'
        5: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:935:in `connect'
        4: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:103:in `timeout'
        3: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout'
        2: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:936:in `block in connect'
        1: from /usr/local/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/net/http.rb:939:in `rescue in block in connect'
Errno::ENETUNREACH (Failed to open TCP connection to sim.speedtest.t-mobile.com:80 (Network is unreachable - connect(2) for "sim.speedtest.t-mobile.com" port 80))
```